### PR TITLE
Rectify .localize() handling of language codes, .substArguments() unsatisfied-args errors in strict mode, reduce excessive warnings, etc

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -764,7 +764,9 @@ window.html10n = (function(window, document, undefined) {
   html10n.get = function(id, args) {
     var translations = html10n.translations
     if(!translations) {
-      if (! html10n.quiet) { consoleWarn('No translations available (yet)'); }
+      if (! html10n.quiet) {
+        consoleWarn('No translations available (yet)');
+      }
       return;
     }
     if(!translations[id]) return consoleWarn('Could not find string '+id)


### PR DESCRIPTION
Fixes marcelklehr/html10n.js#13, marcelklehr/html10n.js#15, and more:
1. (marcelklehr/html10n.js#13) If the `html10n.localize()` array argument includes a language code of the form "ln-cn", then subsequent arguments in the array are replaced with the country-modifier stripped version of that language code (ie for this example, "ln"). So, eg, if you pass `["es-mx", "en"]`, then the routine will convert that to something like `["es-mx", "es", "es"]`. Baad.
   
   The fix instead adds the country-modifier  stripped version of a country-modified language code immediately after the country-modified language code, without disrupting any of the subsequent codes in the array. So the above example would yield `["es-mx", "es", "en"]` - ahh, better.
   
   (The function docstring is also enhanced to describe this behavior.)
2. When running in Javascript strict mode (recommended), unsatisfied arguments cause an error to be thrown in `.substArguments()`. What is supposed to happen, instead, is that a translation be sought to resolve the unsatisfied argument, or failing that a warning is emitted. This pull request fixes things so that now happens, even in strict mode.
3. When checking for the existence of a language, `data[lang]` was being checked, when apparently `data` should be. (I'm unsure about the details of this one - it was adopted by someone else from somewhere else, but it seems to work.)
4. An optional module setting, `html10n.quiet`, is added which, if set (by default it is not defined), prevents the "No translations available (yet)" console log warning. This is crucial for situations like testing, where `html10n.get()` might be called hundreds or thousands of times without the translations being loaded.
5. "-" dash and "_" underscore are added to acceptable translation argument name characters.
