### PR TITLE
Allow region-specific locale falling back to their script counterpart

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -242,6 +242,17 @@ window.html10n = (function(window, document, undefined) {
   html10n.macros = {}
 
   html10n.rtl = ["ar","dv","fa","ha","he","ks","ku","ps","ur","yi"]
+
+  /** 
+   * Language-Script fallbacks for Language-Region language tags, for languages that
+   * varies heavily on writing form and two-part locale expansion is not feasible.
+   * See also: https://tools.ietf.org/html/rfc4646 (RFC 4646)
+   */
+  html10n.scripts = {
+      'zh-tw': 'zh-hant',
+      'zh-hk': 'zh-hant',
+      'zh-cn': 'zh-hans'
+  }
   
   /**
    * Get rules for plural forms (shared with JetPack), see:
@@ -694,9 +705,15 @@ window.html10n = (function(window, document, undefined) {
     var i=0
     langs.forEach(function(lang) {
       if(!lang) return
-      langs[i++] = lang
+      langs[i++] = lang.toLowerCase();
       if(~lang.indexOf('-')) langs[i++] = lang.substr(0, lang.indexOf('-'))
     })
+    
+    // Append script fallbacks for region-specific locales if applicable
+    for (var lang in html10n.scripts) {
+      i = langs.indexOf(lang);
+      if (~i) langs.splice(i, 0, html10n.scripts[lang])
+    }
 
     this.build(langs, function(er, translations) {
       html10n.translations = translations


### PR DESCRIPTION
Currently, html10n would expand two-part locales (“Language-Region” [language tags](https://tools.ietf.org/html/rfc4646#section-2)), allowing them falling back to two-letter language codes if no region-specific translations available. 

However, some [macrolanguages](https://en.wikipedia.org/wiki/ISO_639_macrolanguage) vary heavily on writing forms, simply falling back to two-letter locales would be unfeasible. 

For example, most FOSS projects maintain unified translation for Traditional Chinese (`zh-Hant`) regardless of region, while most browsers specify preferred language through region (`zh-TW` instead of `zh-Hant` or `zh-Hant-TW`). Under current behavior, html10n would fallback to `zh` (effectively `zh-Hans`), which is barely readable for users.

 This pull request would allow region-specific locales fall back to their (wider) script counterpart. Currently it only distinguishes between `zh-Hant` and `zh-Hans`, but other languages would benefit from this as well. (Serbian, for example, could be written in Cyrillic script or Latin script. These region differences could be added upon request.)