### PR TITLE
Allow 'value' attribute to be translated

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -901,6 +901,7 @@ window.html10n = (function(window, document, undefined) {
        , "alt": 1
        , "textContent": 1
        , "placeholder": 1
+       , "value": 1
        }
     if (index > 0 && str.id.substr(index + 1) in attrList) { // an attribute has been specified
       prop = str.id.substr(index + 1)


### PR DESCRIPTION
Some [Etherpad](https://github.com/ether/etherpad-lite/) plugins need that...